### PR TITLE
Added local option to ajax

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -176,7 +176,7 @@
   Dom.ajax = function (options) {
     var xhr = new XMLHttpRequest()
     xhr.onreadystatechange = function () {
-      if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+      if (xhr.readyState === XMLHttpRequest.DONE && (options.local ? xhr.status === 200 || xhr.status === 0 : xhr.status === 200)) {
         if (options.json) {
           try {
             return options.callback(null, JSON.parse(xhr.responseText))


### PR DESCRIPTION
Added `local` option to allow loading local files when using the lib in a hybrid mobile app.
See [here](https://stackoverflow.com/questions/17964383/phonegap-ajax-call-fails-everytime/19498463#19498463) for more info.