### PR TITLE
Better events

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -43,5 +43,7 @@
       <div class="children"></div>
       <div class="children"></div>
     </div>
+    <div id="is"></div>
+    <div id="event"></div>
   </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -275,4 +275,27 @@ function runTest (err, window) {
       t.notOk(children[i] instanceof window.dom)
     }
   })
+
+  test('dom.is should test the given property', t => {
+    t.plan(3)
+    var ele = window.dom('#is')
+    t.false(ele.is('focus'))
+    t.true(ele.is('blur'))
+    t.true(ele.is('visible'))
+  })
+
+  test('dom.is("not") should test the given property', t => {
+    t.plan(3)
+    var ele = window.dom('#is')
+    t.true(ele.is('not focus'))
+    t.false(ele.is('not blur'))
+    t.false(ele.is('not visible'))
+  })
+
+  test('dom.on should add an event listener and a store object to the element', t => {
+    t.plan(2)
+    window.dom('#event').on('click', console.log)
+    t.is(typeof window.dom('#event').element.domLibEventHandlers, 'object')
+    t.true(Array.isArray(window.dom('#event').element.domLibEventHandlers['click']))
+  })
 }


### PR DESCRIPTION
Since you can't use removeEventListener if you haven't the original callback (the same you used in addEventListener) a common way to solve the problem is to append a property to the dom element where you store all the events callbacks.

We could append it as a property of the lib but two different instances of the same element wouldn't share the same events, so we append it to the dom element.

So now we can do:
```js
dom(element).off('click')
```
without cloning the object every time.

_______
Bonus:
*is* function!
Usage:
```js
dom(element).is('focused')
dom(element).is('not visible')
```