### PR TITLE
Collapsible

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -298,6 +298,29 @@
     return this
   }
 
+  Dom.prototype.collapsible = function (opts) {
+    opts = opts || {}
+    opts.time = opts.time || 0.5
+    this.collapsibleHeight = opts.height || this.element.offsetHeight
+    this.css('display: block; height: 0; line-height:0; overflow: hidden; transition: height ' + opts.time + 's, line-height ' + opts.time + 's')
+
+    return {
+      expand: expand.bind(this),
+      collapse: collapse.bind(this)
+    }
+
+    function expand () {
+      this.css('height:' + this.collapsibleHeight + 'px; line-height: initial')
+      return this
+    }
+
+    function collapse () {
+      this.collapsibleHeight = opts.height || this.element.offsetHeight
+      this.css('height: 0')
+      return this
+    }
+  }
+
   global.dom = Dom
   global.$ = global.$ || Dom
 })(window)

--- a/test/test.html
+++ b/test/test.html
@@ -45,5 +45,6 @@
     </div>
     <div id="is"></div>
     <div id="event"></div>
+    <div id="collapsible"></div>
   </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -298,4 +298,25 @@ function runTest (err, window) {
     t.is(typeof window.dom('#event').element.domLibEventHandlers, 'object')
     t.true(Array.isArray(window.dom('#event').element.domLibEventHandlers['click']))
   })
+
+  test('dom.collapsible should return a function that return an instance of dom', t => {
+    t.plan(5)
+    var collapsible = window.dom('#collapsible').collapsible()
+    t.is(typeof collapsible.expand, 'function')
+    t.is(typeof collapsible.collapse, 'function')
+
+    t.ok(collapsible.expand() instanceof window.dom)
+    t.ok(collapsible.collapse() instanceof window.dom)
+
+    t.is(collapsible.expand().element.offsetHeight, window.dom.get('#collapsible').offsetHeight)
+  })
+
+  test('dom.collapsible can accept a custom height instead of the offsetHeight', t => {
+    t.plan(2)
+    var collapsible = window.dom('#collapsible').collapsible({
+      height: 150
+    })
+    t.is(collapsible.expand().element.style.height, '150px')
+    t.is(collapsible.collapse().collapsibleHeight, 150)
+  })
 }


### PR DESCRIPTION
Makes a dom element collapsible.
Example: 
```js
var collapsible = dom('#element').collapsible()
collapsible.expand()
collapsible.collapse()
```
Collapsible returns an instance of `dom`:
```js
var collapsible = dom('#element').collapsible()
collapsible.expand().text('the answer is 42')
```
Collapsible accepts custom height and transition time.
```js
var collapsible = dom('#element').collapsible({
  height: 150, // in pixel, default to offsetHeight
  time: 1      // in seconds, default to 0.5
})
```